### PR TITLE
Added Payment Method

### DIFF
--- a/app/models/solidus_pay_tomorrow.rb
+++ b/app/models/solidus_pay_tomorrow.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  class << self
+    def table_name_prefix
+      'solidus_pt_'
+    end
+  end
+end

--- a/app/models/solidus_pay_tomorrow/payment_method.rb
+++ b/app/models/solidus_pay_tomorrow/payment_method.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  class PaymentMethod < SolidusSupport.payment_method_parent_class
+    preference :username, :string
+    preference :password, :string
+
+    def gateway_class
+      ::SolidusPayTomorrow::Gateway
+    end
+
+    def payment_source_class
+      ::SolidusPayTomorrow::PaymentSource
+    end
+
+    def partial_name
+      'pt'
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,4 +2,6 @@
 # See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
 
 en:
-  hello: Hello world
+  activerecord:
+    models:
+      solidus_pay_tomorrow/payment_method: PayTomorrow

--- a/lib/solidus_pay_tomorrow/configuration.rb
+++ b/lib/solidus_pay_tomorrow/configuration.rb
@@ -2,9 +2,7 @@
 
 module SolidusPayTomorrow
   class Configuration
-    # Define here the settings for this extension, e.g.:
-    #
-    # attr_accessor :my_setting
+    attr_accessor :username, :password
   end
 
   class << self

--- a/lib/solidus_pay_tomorrow/engine.rb
+++ b/lib/solidus_pay_tomorrow/engine.rb
@@ -11,6 +11,19 @@ module SolidusPayTomorrow
 
     engine_name 'solidus_pay_tomorrow'
 
+    initializer 'solidus_pay_tomorrow.add_static_preference', after: 'spree.register.payment_methods' do |app|
+      app.config.spree.payment_methods << 'SolidusPayTomorrow::PaymentMethod'
+      app.config.to_prepare do
+        Spree::Config.static_model_preferences.add(
+          SolidusPayTomorrow::PaymentMethod,
+          'pt_credentials', {
+            username: ENV['PAY_TOMORROW_USERNAME'],
+            password: ENV['PAY_TOMORROW_PASSWORD']
+          }
+        )
+      end
+    end
+
     # use rspec for tests
     config.generators do |g|
       g.test_framework :rspec

--- a/spec/models/solidus_pay_tomorrow/payment_method_spec.rb
+++ b/spec/models/solidus_pay_tomorrow/payment_method_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::PaymentMethod, type: :model do
+  describe '#gateway_class' do
+    it 'has correct gateway class' do
+      expect(described_class.new.gateway_class).to eq SolidusPayTomorrow::Gateway
+    end
+  end
+
+  describe '#payment_source_class' do
+    it 'has correct payment_source class' do
+      expect(described_class.new.payment_source_class).to eq SolidusPayTomorrow::PaymentSource
+    end
+  end
+
+  describe '#partial_name' do
+    it 'has correct partial name' do
+      expect(described_class.new.partial_name).to eq 'pt'
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** https://linear.app/nebulab-retainers/issue/ABU-2/create-the-payment-method 

**Brief:**
We are adding PayTomorrow PSP as a Solidus extension

This PR - 
* Defines `SoliduspayTomorrow::PaymentMethod`
* Adds _username_ and _password_ in config (PayTomorrow's [Auth](https://docs.paytomorrow.com/docs/api-reference/api/authenticate))

Ref Bolt's [PR](https://github.com/solidusio/solidus_bolt/pull/5)