### PR TITLE
Defines SolidusPayTomorrow:Gateway

### DIFF
--- a/app/models/solidus_pay_tomorrow/gateway.rb
+++ b/app/models/solidus_pay_tomorrow/gateway.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  class Gateway
+    def initialize(options = {}); end
+
+    def authorize
+      not_implemented(__method__)
+    end
+
+    def purchase
+      not_implemented(__method__)
+    end
+
+    def capture
+      not_implemented(__method__)
+    end
+
+    def void
+      not_implemented(__method__)
+    end
+
+    def credit
+      not_implemented(__method__)
+    end
+
+    private
+
+    # Remove this once all methods are implemented
+    def not_implemented(method_name)
+      raise NotImplementedError, "#{method_name} method has not been implemented in #{self.class} class"
+    end
+  end
+end

--- a/spec/models/solidus_pay_tomorrow/gateway_spec.rb
+++ b/spec/models/solidus_pay_tomorrow/gateway_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::Gateway, type: :model do
+  describe '#authorize' do
+    it 'raises NotImplementedError' do
+      expect { described_class.new.authorize }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#capture' do
+    it 'raises NotImplementedError' do
+      expect { described_class.new.capture }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#void' do
+    it 'raises NotImplementedError' do
+      expect { described_class.new.void }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#credit' do
+    it 'raises NotImplementedError' do
+      expect { described_class.new.credit }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#purchase' do
+    it 'raises NotImplementedError' do
+      expect { described_class.new.purchase }.to raise_error(NotImplementedError)
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** https://linear.app/nebulab-retainers/issue/ABU-3/create-the-gateway

This PR -
* Defines the necessary methods based on [this](https://github.com/solidusio/solidus/blob/07c88ddd1603699939ac0343965fa88dc2e1851a/core/app/models/spree/payment_method.rb#L76-L87)
* Specs^

Q. Do we need to add **PaymentSource** like in [Bolt](https://github.com/solidusio/solidus_bolt/pull/6/commits/4e880802a01e99cf33069570420570371166b773)?

This PR depends on https://github.com/nebulab/solidus_pay_tomorrow/pull/1