### PR TITLE
Added VoidService and gateway#void

### DIFF
--- a/app/models/solidus_pay_tomorrow/gateway.rb
+++ b/app/models/solidus_pay_tomorrow/gateway.rb
@@ -20,14 +20,24 @@ module SolidusPayTomorrow
       ActiveMerchant::Billing::Response.new(
         true,
         'Transaction Captured', capture_response,
-        'authorization': response_code
+        authorization: response_code
       )
     rescue StandardError => e
       failed_response(e)
     end
 
-    def void
-      not_implemented(__method__)
+    def void(response_code, gateway_options)
+      void_response = SolidusPayTomorrow::Client::VoidService.call(
+        order_token: response_code,
+        payment_method: gateway_options[:originator].payment_method
+      )
+      ActiveMerchant::Billing::Response.new(
+        true,
+        'Transaction Void', void_response,
+        authorization: response_code
+      )
+    rescue StandardError => e
+      failed_response(e)
     end
 
     def credit

--- a/app/services/solidus_pay_tomorrow/client/void_service.rb
+++ b/app/services/solidus_pay_tomorrow/client/void_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  module Client
+    class VoidService < SolidusPayTomorrow::Client::BaseService
+      attr_reader :order_token
+
+      CANCEL_ENDPOINT = 'api/ecommerce/application/:order_token/cancel'
+
+      def initialize(order_token:, payment_method:)
+        @order_token = order_token
+        super
+      end
+
+      def call
+        void
+      end
+
+      private
+
+      def void
+        handle_errors!(HTTParty.post(uri, headers: auth_headers))
+      end
+
+      def uri
+        "#{api_base_url}/#{CANCEL_ENDPOINT.gsub(':order_token', order_token)}"
+      end
+    end
+  end
+end

--- a/spec/services/solidus_pay_tomorrow/client/void_service_spec.rb
+++ b/spec/services/solidus_pay_tomorrow/client/void_service_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::Client::VoidService do
+  let(:payment_method) { create(:pt_payment_method) }
+  let(:headers) {
+    { 'Authorization': "Bearer access-token",
+      'Content-Type': 'application/json' }
+  }
+  let(:url) { "https://api-staging.paytomorrow.com/api/ecommerce/application/order_token/cancel" }
+
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(SolidusPayTomorrow::Client::BaseService).to receive(:valid_token).and_return('access-token')
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  describe '#call' do
+    context 'when successful cancellation' do
+      let(:success_response) do
+        { status: 'ok',
+          message: 'application cancelled',
+          token: nil,
+          maxApprovalAmount: nil,
+          lender: nil }.stringify_keys!
+      end
+      let(:http_response) { instance_double(HTTParty::Response, parsed_response: success_response, success?: true) }
+
+      before do
+        allow(HTTParty).to receive(:post).with(url, headers: headers).and_return(http_response)
+      end
+
+      it 'checks response' do
+        response = described_class.call(order_token: 'order_token', payment_method: payment_method)
+
+        expect(response).to include('status' => 'ok', 'message' => 'application cancelled')
+      end
+    end
+
+    context 'when cancellation fails' do
+      let(:failed_response) do
+        { timestamp: '2022-09-12T09:18:00.219+00:00',
+          status: 400,
+          error: 'Bad Request',
+          message: "",
+          path: '/ecommerce/application/order_token/cancel' }.stringify_keys!
+      end
+      let(:http_response) { instance_double(HTTParty::Response, parsed_response: failed_response, success?: false) }
+
+      before do
+        allow(HTTParty).to receive(:post).with(url, headers: headers).and_return(http_response)
+      end
+
+      it 'raises StandardError' do
+        expect do
+          described_class.call(order_token: 'order_token', payment_method: payment_method)
+        end.to raise_error(StandardError, 'Bad Request: ')
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** https://linear.app/nebulab-retainers/issue/ABU-10/implement-soliduspaytomorrowgatewayvoid

**Brief:**
- [x] Added VoidService in payTomorrow Client
- [x] Added specs for ^
- [x] Use the service in `gateway.rb`
- [x] Update gateway specs