### PR TITLE
Added CreditService and gateway#credit

### DIFF
--- a/app/overrides/spree/admin/refunds/new/remove_partial_amount_selector.html.erb.deface
+++ b/app/overrides/spree/admin/refunds/new/remove_partial_amount_selector.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- replace 'erb[loud]:contains("spree/admin/shared/number_with_currency")' -->
+
+<% unless @refund.payment.payment_method.type == 'SolidusPayTomorrow::PaymentMethod' %>
+   <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :amount, currency: @refund.currency, required: true %>
+<% end %>

--- a/app/overrides/spree/admin/refunds/new/remove_refund_amount_label.html.erb.deface
+++ b/app/overrides/spree/admin/refunds/new/remove_refund_amount_label.html.erb.deface
@@ -1,0 +1,5 @@
+<!-- replace 'erb[loud]:contains("f.label :amount")' -->
+
+<% unless @refund.payment.payment_method.type == 'SolidusPayTomorrow::PaymentMethod' %>
+   <%= f.label :amount %><br/>
+<% end %>

--- a/app/services/solidus_pay_tomorrow/client/credit_service.rb
+++ b/app/services/solidus_pay_tomorrow/client/credit_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  module Client
+    class CreditService < SolidusPayTomorrow::Client::BaseService
+      attr_reader :order_token, :refund_reason
+
+      REFUND_ENDPOINT = 'api/ecommerce/application/:order_token/refund'
+
+      def initialize(order_token:, payment_method:, refund_reason:)
+        @order_token = order_token
+        @refund_reason = refund_reason
+        super
+      end
+
+      def call
+        credit
+      end
+
+      private
+
+      def credit
+        handle_errors!(HTTParty.post(uri, headers: auth_headers, body: refund_body))
+      end
+
+      def uri
+        "#{api_base_url}/#{REFUND_ENDPOINT.gsub(':order_token', order_token)}"
+      end
+
+      def refund_body
+        { reason: refund_reason }.to_json
+      end
+    end
+  end
+end

--- a/solidus_pay_tomorrow.gemspec
+++ b/solidus_pay_tomorrow.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'deface'
   spec.add_dependency 'faraday-retry'
   spec.add_dependency 'httparty'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']

--- a/spec/models/solidus_pay_tomorrow/gateway_spec.rb
+++ b/spec/models/solidus_pay_tomorrow/gateway_spec.rb
@@ -84,15 +84,55 @@ RSpec.describe SolidusPayTomorrow::Gateway, type: :model do
     end
   end
 
-  describe '#authorize' do
-    it 'raises NotImplementedError' do
-      expect { described_class.new.authorize }.to raise_error(NotImplementedError)
+  describe '#credit' do
+    let(:credit_success_response) do
+      { status: 'ok',
+        message: 'application refunded',
+        token: nil,
+        maxApprovalAmount: nil,
+        lender: nil }.stringify_keys!
+    end
+    let(:refund_reason) { create(:refund_reason) }
+    let(:refund) { create(:refund, reason: refund_reason) }
+
+    context 'when /refund call succeeds' do
+      before do
+        allow(SolidusPayTomorrow::Client::CreditService).to receive(:call).with(
+          order_token: payment.response_code,
+          payment_method: payment_method,
+          refund_reason: refund_reason.name
+        ).and_return(credit_success_response)
+      end
+
+      it 'returns an active merchant billing success response' do
+        result = described_class.new.credit(
+          payment.amount.to_f,
+          payment.response_code,
+          originator: refund
+        )
+        expect(result).to be_an_instance_of(ActiveMerchant::Billing::Response)
+        expect(result).to be_success
+      end
+    end
+
+    context 'when /refund call fails' do
+      before do
+        allow(SolidusPayTomorrow::Client::CreditService).to receive(:call).and_raise(StandardError)
+      end
+
+      it 'returns an active merchant billing failure response' do
+        result = described_class.new.credit(payment.amount.to_f,
+          payment.response_code,
+          originator: refund)
+        expect(result).to be_an_instance_of(ActiveMerchant::Billing::Response)
+        expect(result).not_to be_success
+      end
     end
   end
 
-  describe '#credit' do
+  describe '#authorize' do
     it 'raises NotImplementedError' do
-      expect { described_class.new.credit }.to raise_error(NotImplementedError)
+      expect { described_class.new.authorize }.to raise_error(NotImplementedError)
     end
   end
 

--- a/spec/models/solidus_pay_tomorrow/gateway_spec.rb
+++ b/spec/models/solidus_pay_tomorrow/gateway_spec.rb
@@ -61,11 +61,14 @@ RSpec.describe SolidusPayTomorrow::Gateway, type: :model do
     end
 
     context 'when /cancel call succeeds' do
-      it 'returns an active merchant billing success response' do
+      before do
         allow(SolidusPayTomorrow::Client::VoidService).to receive(:call).with(
           order_token: payment.response_code,
           payment_method: payment_method
         ).and_return(void_success_response)
+      end
+
+      it 'returns an active merchant billing success response' do
         result = described_class.new.void(payment.response_code,
           originator: payment)
         expect(result).to be_an_instance_of(ActiveMerchant::Billing::Response)
@@ -74,8 +77,11 @@ RSpec.describe SolidusPayTomorrow::Gateway, type: :model do
     end
 
     context 'when /cancel call fails' do
-      it 'returns an active merchant billing failure response' do
+      before do
         allow(SolidusPayTomorrow::Client::VoidService).to receive(:call).and_raise(StandardError)
+      end
+
+      it 'returns an active merchant billing failure response' do
         result = described_class.new.void(payment.response_code,
           originator: payment)
         expect(result).to be_an_instance_of(ActiveMerchant::Billing::Response)

--- a/spec/services/solidus_pay_tomorrow/client/credit_service_spec.rb
+++ b/spec/services/solidus_pay_tomorrow/client/credit_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::Client::CreditService do
+  let(:payment_method) { create(:pt_payment_method) }
+  let(:headers) {
+    { 'Authorization': "Bearer access-token",
+      'Content-Type': 'application/json' }
+  }
+  let(:url) { "https://api-staging.paytomorrow.com/api/ecommerce/application/order_token/refund" }
+  let(:http_response) { instance_double(HTTParty::Response, parsed_response: success_response, success?: true) }
+  let(:refund_body) { { reason: 'refund reason' }.to_json }
+
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(SolidusPayTomorrow::Client::BaseService).to receive(:valid_token).and_return('access-token')
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  describe '#call' do
+    context 'when successful refund' do
+      let(:success_response) do
+        { status: 'ok',
+          message: 'application refunded',
+          token: nil,
+          maxApprovalAmount: nil,
+          lender: nil }.stringify_keys!
+      end
+      let(:http_response) { instance_double(HTTParty::Response, parsed_response: success_response, success?: true) }
+
+      before do
+        allow(HTTParty).to receive(:post).with(url, headers: headers, body: refund_body).and_return(http_response)
+      end
+
+      it 'checks response' do
+        response = described_class.call(order_token: 'order_token', refund_reason: 'refund reason',
+          payment_method: payment_method)
+
+        expect(response).to include('status' => 'ok', 'message' => 'application refunded')
+      end
+    end
+
+    context 'when refund fails' do
+      let(:failed_response) do
+        { timestamp: '2022-09-12T09:18:00.219+00:00',
+          status: 400,
+          error: 'Bad Request',
+          message: "",
+          path: '/ecommerce/application/order_token/refund' }.stringify_keys!
+      end
+      let(:http_response) { instance_double(HTTParty::Response, parsed_response: failed_response, success?: false) }
+
+      before do
+        allow(HTTParty).to receive(:post).with(url, headers: headers, body: refund_body).and_return(http_response)
+      end
+
+      it 'raises StandardError' do
+        expect do
+          described_class.call(order_token: 'order_token', refund_reason: 'refund reason',
+            payment_method: payment_method)
+        end.to raise_error(StandardError, 'Bad Request: ')
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** https://linear.app/nebulab-retainers/issue/ABU-12/implement-soliduspaytomorrowgatewaycredit

**Brief:** This PR adds the functionality to allow PayTomorrow refunds

- [x] Added **CreditService** in payTomorrow Client
- [x] Added specs for ^
- [x] Use the service in `gateway.rb`
- [x] Update gateway specs
- [x] Added deface gem
- [x] Add deface overrides to avoid partial refunds  

**Working of deface override if payment is not PayTomorrow (default behavior)**

<img width="1380" alt="refund_not_pay_tomorrow" src="https://user-images.githubusercontent.com/9041163/199185358-9efea8ab-4579-4494-bd65-4e3a96d33bc1.png">


**Working of deface override if payment is PayTomorrow (don't show partial refund)**

<img width="1036" alt="refund_pay_tomorrow" src="https://user-images.githubusercontent.com/9041163/199185483-6b068991-6ea0-49a1-96cd-0d806b033445.png">

