### PR TITLE
Added BaseService and OrderCreationService

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,9 @@ require:
 
 AllCops:
   NewCops: disable
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Max: 5

--- a/app/models/solidus_pay_tomorrow/payment_method.rb
+++ b/app/models/solidus_pay_tomorrow/payment_method.rb
@@ -4,6 +4,7 @@ module SolidusPayTomorrow
   class PaymentMethod < SolidusSupport.payment_method_parent_class
     preference :username, :string
     preference :password, :string
+    preference :signature, :string
 
     def gateway_class
       ::SolidusPayTomorrow::Gateway

--- a/app/services/solidus_pay_tomorrow/client/base_service.rb
+++ b/app/services/solidus_pay_tomorrow/client/base_service.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'httparty'
+
+module SolidusPayTomorrow
+  module Client
+    class BaseService
+      attr_reader :payment_method
+
+      STAGING_URL = 'https://api-staging.paytomorrow.com'
+      PRODUCTION_URL = 'https://api.paytomorrow.com'
+      AUTH_ENDPOINT = 'api/uaa/oauth/token'
+
+      def initialize(payment_method:, **_args)
+        @payment_method = payment_method
+      end
+
+      class << self
+        attr_accessor :current_token
+
+        def call(*args, **kwargs, &block)
+          new(*args, **kwargs, &block).call
+        end
+      end
+
+      def valid_token
+        new_token if current_token_invalid?
+        self.class.current_token[:access_token]
+      end
+
+      private
+
+      def api_base_url
+        if payment_method.preferred_test_mode
+          STAGING_URL
+        else
+          PRODUCTION_URL
+        end
+      end
+
+      def auth_headers
+        { 'Authorization': "Bearer #{valid_token}",
+          'Content-Type': 'application/json' }
+      end
+
+      def handle_errors!(result)
+        return result.parsed_response if result.success?
+
+        raise StandardError, result.parsed_response['error']
+      end
+
+      def new_token
+        result = handle_errors!(HTTParty.post(token_uri, headers: token_headers, body: URI.encode_www_form(token_body)))
+        self.class.current_token =
+          { expires_at: Time.zone.now + result['expires_in'].seconds }.merge!(result.symbolize_keys)
+      end
+
+      # Tokens are valid for 10-12 hours, if they are near expiry, get new token
+      def current_token_invalid?
+        self.class.current_token.nil? || Time.zone.now > self.class.current_token[:expires_at] - 10.minutes
+      end
+
+      def token_uri
+        "#{api_base_url}/#{AUTH_ENDPOINT}"
+      end
+
+      def token_headers
+        { 'Accept': 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': "Basic #{payment_method.preferences[:signature]}" }
+      end
+
+      def token_body
+        { grant_type: 'password',
+          scope: 'openid',
+          username: payment_method.preferences[:username],
+          password: payment_method.preferences[:password] }
+      end
+    end
+  end
+end

--- a/app/services/solidus_pay_tomorrow/client/create_order_service.rb
+++ b/app/services/solidus_pay_tomorrow/client/create_order_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  module Client
+    class CreateOrderService < SolidusPayTomorrow::Client::BaseService
+      attr_reader :order
+
+      CREATE_ENDPOINT = 'api/application/ecommerce/orders'
+
+      # @param order [Spree::Order] Spree order
+      # @param payment_method [SolidusPayTomorrow::PaymentMethod]
+      def initialize(order:, payment_method:)
+        @order = order
+        super
+      end
+
+      def call
+        create
+      end
+
+      private
+
+      def create
+        handle_errors!(HTTParty.post(uri, headers: auth_headers, body: create_body.to_json))
+      end
+
+      def uri
+        "#{api_base_url}/#{CREATE_ENDPOINT}"
+      end
+
+      # TODO: Update URI once implemented
+      def webhook_url(type)
+        "https://domain.com/webhooks/#{type}"
+      end
+
+      def create_body
+        { orderId: order.number,
+          firstName: full_name.first_name,
+          lastName: full_name.last_name,
+          street: order.bill_address.address1,
+          city: order.bill_address.city,
+          zip: order.bill_address.zipcode,
+          state: order.bill_address.state.abbr,
+          email: order.email,
+          returnUrl: webhook_url('return'),
+          cancelUrl: webhook_url('cancel'),
+          notifyUrl: webhook_url('notify'),
+          cellPhone: order.bill_address.phone,
+          loanAmount: order.total.to_i,
+          applicationItems: items }
+      end
+
+      def full_name
+        Spree::Address::Name.new(order.bill_address.name)
+      end
+
+      # Ref: https://docs.paytomorrow.com/docs/api-reference/api/create-order/
+      # for API ref
+      def items
+        order.line_items.map do |line_item|
+          { description: line_item.product.description,
+            quantity: line_item.quantity,
+            price: line_item.price.to_f,
+            sku: line_item.variant.sku }
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_pay_tomorrow/configuration.rb
+++ b/lib/solidus_pay_tomorrow/configuration.rb
@@ -2,7 +2,7 @@
 
 module SolidusPayTomorrow
   class Configuration
-    attr_accessor :username, :password
+    attr_accessor :username, :password, :signature
   end
 
   class << self

--- a/lib/solidus_pay_tomorrow/engine.rb
+++ b/lib/solidus_pay_tomorrow/engine.rb
@@ -18,7 +18,8 @@ module SolidusPayTomorrow
           SolidusPayTomorrow::PaymentMethod,
           'pt_credentials', {
             username: ENV['PAY_TOMORROW_USERNAME'],
-            password: ENV['PAY_TOMORROW_PASSWORD']
+            password: ENV['PAY_TOMORROW_PASSWORD'],
+            signature: ENV['PAY_TOMORROW_SIGNATURE']
           }
         )
       end

--- a/lib/solidus_pay_tomorrow/testing_support/factories.rb
+++ b/lib/solidus_pay_tomorrow/testing_support/factories.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :pt_payment_method, class: SolidusPayTomorrow::PaymentMethod do
+    name { 'PayTomorrow' }
+  end
 end

--- a/solidus_pay_tomorrow.gemspec
+++ b/solidus_pay_tomorrow.gemspec
@@ -29,8 +29,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'faraday-retry'
+  spec.add_dependency 'httparty'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'
 
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'solidus_dev_support', '~> 2.5'
 end

--- a/spec/services/solidus_pay_tomorrow/client/base_service_spec.rb
+++ b/spec/services/solidus_pay_tomorrow/client/base_service_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::Client::BaseService do
+  let(:payment_method) { create(:pt_payment_method) }
+  let(:token) do
+    { access_token: "ad0cf6c6-6ef3-4185-8a25-ff575075fbc1",
+      token_type: "bearer",
+      refresh_token: "da8bf03e-4de4-4999-9f07-e446e39e9e88",
+      expires_in: 38_488,
+      scope: "openid" }
+  end
+
+  describe '#valid_token' do
+    context "when current token is valid" do
+      before do
+        # Ensure that current token is set and valid
+        described_class.current_token = token.merge({ expires_at: Time.zone.now + 10.hours })
+        allow(HTTParty).to receive(:post)
+      end
+
+      it 'returns current token' do
+        expect(described_class.new(payment_method: payment_method).valid_token).to eq(token[:access_token])
+        expect(HTTParty).not_to have_received(:post).with(anything)
+      end
+    end
+
+    context "when current token is invalid" do
+      let(:token_url) { 'https://api-staging.paytomorrow.com/api/uaa/oauth/token' }
+      let(:token_headers) do
+        { 'Accept': 'application/json',
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': "Basic #{payment_method.preferences[:signature]}" }
+      end
+      let(:token_body) do
+        { grant_type: 'password',
+          scope: 'openid',
+          username: payment_method.preferences[:username],
+          password: payment_method.preferences[:password] }
+      end
+      let(:http_response) { instance_double(HTTParty::Response, parsed_response: token.stringify_keys, success?: true) }
+
+      before do
+        allow(HTTParty).to receive(:post).with(token_url, headers: token_headers,
+          body: URI.encode_www_form(token_body)).and_return(http_response)
+      end
+
+      it 'if not present, fetches new token and stores' do
+        # Ensure that current token is not set
+        described_class.current_token = nil
+        expect(described_class.new(payment_method: payment_method).valid_token).to eq(token[:access_token])
+        expect(HTTParty).to have_received(:post).with(token_url, headers: token_headers,
+          body: URI.encode_www_form(token_body))
+        expect(described_class.current_token).to match(hash_including(*token.keys, :expires_at))
+      end
+
+      it 'if expired, fetches new token and stores' do
+        # Ensure that current token is set and expired
+        described_class.current_token = token.merge({ expires_at: Time.zone.now - 10.hours })
+        expect(described_class.new(payment_method: payment_method).valid_token).to eq(token[:access_token])
+        expect(HTTParty).to have_received(:post).with(token_url, headers: token_headers,
+          body: URI.encode_www_form(token_body))
+        expect(described_class.current_token).to match(hash_including(*token.keys, :expires_at))
+      end
+    end
+  end
+end

--- a/spec/services/solidus_pay_tomorrow/client/create_order_service_spec.rb
+++ b/spec/services/solidus_pay_tomorrow/client/create_order_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::Client::CreateOrderService do
+  let(:order) { create(:order_with_line_items, line_items_count: 2) }
+  let(:payment_method) { create(:pt_payment_method) }
+  let(:success_response) do
+    { url: "https://subdomain.paytomorrow.com/verify/personal?app=11171280-8e2a-4b2e-8855-76285fc578c6&auth=e3de6c12-ed9a-4bb1-a066-5c62a1ba19d4",
+      token: "11171280-8e2a-4b2e-8855-76285fc578c6" }.stringify_keys!
+  end
+  let(:http_response) { instance_double(HTTParty::Response, parsed_response: success_response, success?: true) }
+  let(:full_name) { Spree::Address::Name.new(order.bill_address.name) }
+
+  before do
+    url = 'https://api-staging.paytomorrow.com/api/application/ecommerce/orders'
+    headers = { 'Authorization': "Bearer access-token",
+                'Content-Type': 'application/json' }
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(SolidusPayTomorrow::Client::BaseService).to receive(:valid_token).and_return('access-token')
+    # rubocop:enable RSpec/AnyInstance
+    allow(HTTParty).to receive(:post).with(url, headers: headers, body: expected_body).and_return(http_response)
+  end
+
+  describe '#call' do
+    it 'creates successful order' do
+      response = described_class.call(order: order, payment_method: payment_method)
+      expect(response).to match(hash_including('url', 'token'))
+    end
+
+    def expected_body
+      { orderId: order.number,
+        firstName: full_name.first_name,
+        lastName: full_name.last_name,
+        street: order.bill_address.address1,
+        city: order.bill_address.city,
+        zip: order.bill_address.zipcode,
+        state: order.bill_address.state.abbr,
+        email: order.email,
+        returnUrl: 'https://domain.com/webhooks/return',
+        cancelUrl: 'https://domain.com/webhooks/cancel',
+        notifyUrl: 'https://domain.com/webhooks/notify',
+        cellPhone: order.bill_address.phone,
+        loanAmount: order.total.to_i,
+        applicationItems:
+          [{ description: "As seen on TV!", quantity: 1, price: 10.0, sku: "SKU-1" },
+           { description: "As seen on TV!", quantity: 1, price: 10.0, sku: "SKU-2" }] }.to_json
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ ENV['RAILS_ENV'] = 'test'
 
 # Run Coverage report
 require 'solidus_dev_support/rspec/coverage'
+require 'pry-byebug'
 
 # Create the dummy app if it's still missing.
 dummy_env = "#{__dir__}/dummy/config/environment.rb"


### PR DESCRIPTION
**Brief:** https://linear.app/nebulab-retainers/issue/ABU-6/create-paytomorrow-order

- [x] Added code to create payTomorrow order from console with valid access token
- [x] Specs

**Usage ->**
Prerequisite -
1. Make sure you have a **SolidusPayTomorrow::PaymentMethod** with valid username, password and signature. This can be done from the UI via the sandbox app or rails console
2. Make sure you have an order with **total > 500** 

Once yo have these 2, do this in rails console to create an order on PayTomorrow

```ruby
# Given that you have `order` and `payment_method` vars set
SolidusPayTomorrow::Client::CreateOrderService.call(order:, payment_method:)
```

This should return with the checkout URL and order token 