### PR TITLE
Added SolidusPayTomorrowPaymentSource

### DIFF
--- a/app/models/solidus_pay_tomorrow.rb
+++ b/app/models/solidus_pay_tomorrow.rb
@@ -3,7 +3,7 @@
 module SolidusPayTomorrow
   class << self
     def table_name_prefix
-      'solidus_pt_'
+      'solidus_pay_tomorrow_'
     end
   end
 end

--- a/app/models/solidus_pay_tomorrow/payment_method.rb
+++ b/app/models/solidus_pay_tomorrow/payment_method.rb
@@ -17,9 +17,5 @@ module SolidusPayTomorrow
     def partial_name
       'pay_tomorrow'
     end
-
-    def source_required?
-      false
-    end
   end
 end

--- a/app/models/solidus_pay_tomorrow/payment_source.rb
+++ b/app/models/solidus_pay_tomorrow/payment_source.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require_dependency 'solidus_pay_tomorrow'
+
 module SolidusPayTomorrow
-  class PaymentSource < SolidusSupport.payment_source_parent_class
+  class PaymentSource < Spree::PaymentSource
+    validates :payment_method_id, presence: true
   end
 end

--- a/app/services/solidus_pay_tomorrow/handle_order_creation_service.rb
+++ b/app/services/solidus_pay_tomorrow/handle_order_creation_service.rb
@@ -25,8 +25,12 @@ module SolidusPayTomorrow
     def create_payment
       return unless order_successfully_created?
 
-      order.payments.create!(payment_method: payment_method, state: :checkout, response_code: @result['token'],
-        amount: @order.total)
+      ActiveRecord::Base.transaction do
+        source = SolidusPayTomorrow::PaymentSource.create!(application_token: @result['token'],
+          payment_method: payment_method)
+        order.payments.create!(payment_method: payment_method, source: source, state: :checkout,
+          response_code: @result['token'], amount: @order.total)
+      end
     end
 
     def order_successfully_created?

--- a/db/migrate/20221020101815_create_solidus_pay_tomorrow_payment_sources.rb
+++ b/db/migrate/20221020101815_create_solidus_pay_tomorrow_payment_sources.rb
@@ -1,0 +1,10 @@
+class CreateSolidusPayTomorrowPaymentSources < ActiveRecord::Migration[6.1]
+  def change
+    create_table :solidus_pay_tomorrow_payment_sources do |t|
+      t.string :application_token
+      t.references :payment_method, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/solidus_pay_tomorrow/testing_support/factories.rb
+++ b/lib/solidus_pay_tomorrow/testing_support/factories.rb
@@ -4,4 +4,9 @@ FactoryBot.define do
   factory :pt_payment_method, class: SolidusPayTomorrow::PaymentMethod do
     name { 'PayTomorrow' }
   end
+
+  factory :pt_payment_source, class: SolidusPayTomorrow::PaymentSource do
+    payment_method
+    application_token { 'order-token' }
+  end
 end

--- a/solidus_pay_tomorrow.gemspec
+++ b/solidus_pay_tomorrow.gemspec
@@ -34,5 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'solidus_support', '~> 0.5'
 
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'shoulda-matchers', '~> 5.0'
   spec.add_development_dependency 'solidus_dev_support', '~> 2.5'
 end

--- a/spec/models/solidus_pay_tomorrow/payment_source_spec.rb
+++ b/spec/models/solidus_pay_tomorrow/payment_source_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::PaymentSource, type: :model do
+  let(:payment_method) { create(:pt_payment_method) }
+  let(:payment_source) { build(:pt_payment_source, payment_method: payment_method) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:payment_method_id) }
+  end
+end

--- a/spec/services/solidus_pay_tomorrow/handle_order_creation_service_spec.rb
+++ b/spec/services/solidus_pay_tomorrow/handle_order_creation_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SolidusPayTomorrow::HandleOrderCreationService do
         described_class.call(order: order, payment_method: payment_method)
       end.to change { order.payments.count }.from(0).to(1)
       expect(order.payments.take).to have_attributes(state: 'checkout', response_code: 'order-token',
-        amount: order.total)
+        amount: order.total, source: an_instance_of(SolidusPayTomorrow::PaymentSource))
     end
   end
 

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,8 @@
+require "shoulda/matchers"
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
**Ticket:** https://linear.app/nebulab-retainers/issue/ABU-18/create-paymentsource-for-paytomorrow

1. Added the migration for table
2. Fixed table_name_prefix so that the model can refer to the table
3. Added model factory and specs