### PR TITLE
Don't put payment in pending state in OrderApplicationController

### DIFF
--- a/lib/generators/solidus_pay_tomorrow/install/templates/solidus_pay_tomorrow_order_application_controller.rb
+++ b/lib/generators/solidus_pay_tomorrow/install/templates/solidus_pay_tomorrow_order_application_controller.rb
@@ -3,7 +3,6 @@
 module SolidusPayTomorrow
   class OrderApplicationController < Spree::StoreController
     def success
-      payment.update!(state: :pending)
       current_order.next!
 
       flash[:notice] = 'Payment Successful!'

--- a/spec/requests/solidus_pay_tomorrow/order_application_controller_spec.rb
+++ b/spec/requests/solidus_pay_tomorrow/order_application_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SolidusPayTomorrow::OrderApplicationController, type: :request do
         expect(get(spree.pay_tomorrow_return_path)).to redirect_to('/checkout/confirm')
 
         expect(order.state).to eq('confirm')
-        expect(payment.reload.state).to eq('pending')
+        expect(payment.reload.state).to eq('checkout')
       end
     end
   end


### PR DESCRIPTION
**Issue:** https://linear.app/nebulab-retainers/issue/ABU-20/dont-mark-payments-status-as-pending-in-orderapplicationcontroller

**Reasons -**
1. The state machine expects the payment to be in checkout state in order to run process! This is needed for auto-capture
2. Marking payment as pending is not achieving anything and is not actually needed. checkout is fine

- [x] QAed