### PR TITLE
Add can_void? to payment_method

### DIFF
--- a/app/models/solidus_pay_tomorrow/payment_method.rb
+++ b/app/models/solidus_pay_tomorrow/payment_method.rb
@@ -6,6 +6,10 @@ module SolidusPayTomorrow
     preference :password, :string
     preference :signature, :string
 
+    # If a payment has one of these states, then it can't be voided
+    # on PayTomorrow
+    NOT_VOIDABLE_STATES = %w[completed invalid void].freeze
+
     def gateway_class
       ::SolidusPayTomorrow::Gateway
     end

--- a/app/models/solidus_pay_tomorrow/payment_source.rb
+++ b/app/models/solidus_pay_tomorrow/payment_source.rb
@@ -5,5 +5,13 @@ require_dependency 'solidus_pay_tomorrow'
 module SolidusPayTomorrow
   class PaymentSource < Spree::PaymentSource
     validates :payment_method_id, presence: true
+
+    def can_void?(payment)
+      if SolidusPayTomorrow::PaymentMethod::NOT_VOIDABLE_STATES.include?(payment.state)
+        return false
+      end
+
+      true
+    end
   end
 end

--- a/spec/models/solidus_pay_tomorrow/payment_source_spec.rb
+++ b/spec/models/solidus_pay_tomorrow/payment_source_spec.rb
@@ -7,4 +7,40 @@ RSpec.describe SolidusPayTomorrow::PaymentSource, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:payment_method_id) }
   end
+
+  describe "#can_void?" do
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:complete) }
+    let(:payment) {
+      build_stubbed(:payment, order: order, payment_method: payment_method, source: payment_source,
+        state: :completed, response_code: payment_source.application_token,
+        amount: order.total)
+    }
+
+    context 'when payment is in state - completed' do
+      it 'returns false' do
+        expect(payment_source).not_to be_can_void(payment)
+      end
+    end
+
+    context 'when payment is in state - invalid' do
+      it 'returns false' do
+        payment.state = 'invalid'
+        expect(payment_source).not_to be_can_void(payment)
+      end
+    end
+
+    context 'when payment is in state - void' do
+      it 'returns false' do
+        payment.state = 'void'
+        expect(payment_source).not_to be_can_void(payment)
+      end
+    end
+
+    context 'when payment is in state - pending' do
+      it 'returns true' do
+        payment.state = 'pending'
+        expect(payment_source).to be_can_void(payment)
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Issue:** https://linear.app/nebulab-retainers/issue/ABU-21/add-can-void

If a payment is completed (settled on PayTomorrow), invalid or void then it can't be voided on PayTomorrow
Hence by adding this, we ensure that solidus doesn't give void option to admin for these 3 payment states

**Earlier:**
<img width="862" alt="image" src="https://user-images.githubusercontent.com/9041163/198568728-f4b4b2c7-e491-49b6-875b-8650833ab32b.png">


**Now:**
<img width="894" alt="image" src="https://user-images.githubusercontent.com/9041163/198568812-4ec6bc70-e9f9-4074-82c4-38e585e497cd.png">
