### PR TITLE
[Bug fix] Don't call authorize after confirm->complete step

### DIFF
--- a/lib/generators/solidus_pay_tomorrow/install/templates/solidus_pay_tomorrow_order_application_controller.rb
+++ b/lib/generators/solidus_pay_tomorrow/install/templates/solidus_pay_tomorrow_order_application_controller.rb
@@ -3,6 +3,10 @@
 module SolidusPayTomorrow
   class OrderApplicationController < Spree::StoreController
     def success
+      # If auto_capture is disabled, the payment is already processed and
+      # it'll be captured from admin. Marking as pending is necessary to avoid
+      # calling authorize! in this case
+      payment.update!(state: :pending) unless payment.payment_method.auto_capture?
       current_order.next!
 
       flash[:notice] = 'Payment Successful!'

--- a/spec/requests/solidus_pay_tomorrow/order_application_controller_spec.rb
+++ b/spec/requests/solidus_pay_tomorrow/order_application_controller_spec.rb
@@ -19,10 +19,25 @@ RSpec.describe SolidusPayTomorrow::OrderApplicationController, type: :request do
   end
 
   describe 'GET /pay_tomorrow/return' do
-    context 'when PayTomorrow redirects on return URL - success ' do
+    context 'when PayTomorrow redirects on return URL - success & auto_capture is disabled' do
       it 'set correct order and payment status and redirect' do
         # Ensure that the order is in 'payment' state and payment is in 'checkout' state
         # before the request
+        expect(order.state).to eq('payment')
+        expect(payment.reload.state).to eq('checkout')
+        expect(get(spree.pay_tomorrow_return_path)).to redirect_to('/checkout/confirm')
+
+        expect(order.state).to eq('confirm')
+        expect(payment.reload.state).to eq('pending')
+      end
+    end
+
+    context 'when PayTomorrow redirects on return URL - success & auto_capture is enabled' do
+      before do
+        payment_method.update!(auto_capture: true)
+      end
+
+      it 'set correct order and payment status and redirect' do
         expect(order.state).to eq('payment')
         expect(payment.reload.state).to eq('checkout')
         expect(get(spree.pay_tomorrow_return_path)).to redirect_to('/checkout/confirm')


### PR DESCRIPTION
**Issue:** https://linear.app/nebulab-retainers/issue/ABU-22/[bug]-confirm-complete-step-fails-when-auto-capture-is-disabled

**Brief:**
Solidus assumes payments in `checkout` state as unprocessed_payments and calls `purchase` when auto-capture is `enabled` and
`authorize` when auto_capture is `disabled`

To enable this -
The payment should be in `checkout` state when auto_capture is `enabled`. So that `purchase` is implicitly called &
**The payment should be in `pending` state when auto_capture is `disabled`. So that `authorize` is NOT called**

This PR does the second part(in **bold**) in this^

- [x] QAed both scenarios (auto capture enabled and disabled)