### PR TITLE
Implements single partial refund

### DIFF
--- a/app/models/solidus_pay_tomorrow/payment_source.rb
+++ b/app/models/solidus_pay_tomorrow/payment_source.rb
@@ -13,5 +13,15 @@ module SolidusPayTomorrow
 
       true
     end
+
+    # PayTomorrow orders can only process a single refund (partial or full)
+    # Hence don't show option for refund if there's already an existing refund
+    def can_credit?(payment)
+      return false if payment.refunds.exists?
+
+      return true if payment.state == 'completed'
+
+      false
+    end
   end
 end

--- a/app/overrides/spree/admin/refunds/new/remove_partial_amount_selector.html.erb.deface
+++ b/app/overrides/spree/admin/refunds/new/remove_partial_amount_selector.html.erb.deface
@@ -1,5 +1,0 @@
-<!-- replace 'erb[loud]:contains("spree/admin/shared/number_with_currency")' -->
-
-<% unless @refund.payment.payment_method.type == 'SolidusPayTomorrow::PaymentMethod' %>
-   <%= render "spree/admin/shared/number_with_currency", f: f, amount_attr: :amount, currency: @refund.currency, required: true %>
-<% end %>

--- a/app/overrides/spree/admin/refunds/new/remove_refund_amount_label.html.erb.deface
+++ b/app/overrides/spree/admin/refunds/new/remove_refund_amount_label.html.erb.deface
@@ -1,5 +1,0 @@
-<!-- replace 'erb[loud]:contains("f.label :amount")' -->
-
-<% unless @refund.payment.payment_method.type == 'SolidusPayTomorrow::PaymentMethod' %>
-   <%= f.label :amount %><br/>
-<% end %>

--- a/app/services/solidus_pay_tomorrow/client/partial_credit_service.rb
+++ b/app/services/solidus_pay_tomorrow/client/partial_credit_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  module Client
+    class PartialCreditService < SolidusPayTomorrow::Client::BaseService
+      attr_reader :refund
+
+      PARTIAL_REFUND_ENDPOINT = 'api/ecommerce/application/:order_token/partial/refund'
+
+      def initialize(refund:, payment_method:)
+        @refund = refund
+        super
+      end
+
+      def call
+        partial_credit
+      end
+
+      private
+
+      def order_token
+        refund.payment.response_code
+      end
+
+      def partial_credit
+        handle_errors!(HTTParty.post(uri, headers: auth_headers, body: partial_refund_body.to_json))
+      end
+
+      def uri
+        "#{api_base_url}/#{PARTIAL_REFUND_ENDPOINT.gsub(':order_token', order_token)}"
+      end
+
+      def partial_refund_body
+        { loanAmount: refund.amount,
+          items: items }
+      end
+
+      def items
+        refund.payment.order.line_items.map do |line_item|
+          { description: line_item.description,
+            quantity: line_item.quantity,
+            price: line_item.price.to_f }
+        end
+      end
+    end
+  end
+end

--- a/solidus_pay_tomorrow.gemspec
+++ b/solidus_pay_tomorrow.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'deface'
   spec.add_dependency 'faraday-retry'
   spec.add_dependency 'httparty'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']

--- a/spec/models/solidus_pay_tomorrow/payment_source_spec.rb
+++ b/spec/models/solidus_pay_tomorrow/payment_source_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 RSpec.describe SolidusPayTomorrow::PaymentSource, type: :model do
   let(:payment_method) { create(:pt_payment_method) }
-  let(:payment_source) { build(:pt_payment_source, payment_method: payment_method) }
+  let(:payment_source) { create(:pt_payment_source, payment_method: payment_method) }
+  let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:complete) }
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:payment_method_id) }
   end
 
   describe "#can_void?" do
-    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:complete) }
     let(:payment) {
       build_stubbed(:payment, order: order, payment_method: payment_method, source: payment_source,
         state: :completed, response_code: payment_source.application_token,
@@ -40,6 +40,39 @@ RSpec.describe SolidusPayTomorrow::PaymentSource, type: :model do
       it 'returns true' do
         payment.state = 'pending'
         expect(payment_source).to be_can_void(payment)
+      end
+    end
+  end
+
+  describe "#can_credit?" do
+    let(:payment_state) { :completed }
+    let(:payment) {
+      create(:payment, order: order, payment_method: payment_method, source: payment_source,
+        state: payment_state, response_code: payment_source.application_token,
+        amount: order.total)
+    }
+
+    context 'when a refund already exists for the payment' do
+      before do
+        create(:refund, payment: payment, amount: payment.amount)
+      end
+
+      it 'returns false' do
+        expect(payment_source).not_to be_can_credit(payment)
+      end
+    end
+
+    context 'when payment is in state - completed' do
+      it 'returns true' do
+        expect(payment_source).to be_can_credit(payment)
+      end
+    end
+
+    context 'when payment is in state - pending' do
+      let(:payment_state) { :pending }
+
+      it 'returns true' do
+        expect(payment_source).not_to be_can_credit(payment)
       end
     end
   end

--- a/spec/services/solidus_pay_tomorrow/client/partial_credit_service_spec.rb
+++ b/spec/services/solidus_pay_tomorrow/client/partial_credit_service_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::Client::PartialCreditService do
+  let(:payment_method) { create(:pt_payment_method) }
+  let(:payment_source) { create(:pt_payment_source, payment_method: payment_method) }
+  let(:payment) {
+    create(:payment, order: order, payment_method: payment_method, source: payment_source,
+      state: :completed, response_code: payment_source.application_token,
+      amount: order.total)
+  }
+  let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:complete) }
+  let(:refund_reason) { create(:refund_reason) }
+  let(:refund) { create(:refund, payment: payment, amount: payment.amount - 1, reason: refund_reason) }
+
+  let(:headers) {
+    { 'Authorization': "Bearer access-token",
+      'Content-Type': 'application/json' }
+  }
+  let(:url) { "https://api-staging.paytomorrow.com/api/ecommerce/application/order-token/partial/refund" }
+  let(:http_response) { instance_double(HTTParty::Response, parsed_response: success_response, success?: true) }
+
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(SolidusPayTomorrow::Client::BaseService).to receive(:valid_token).and_return('access-token')
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  describe '#call' do
+    context 'when successful partial refund' do
+      let(:success_response) do
+        { status: 'ok',
+          message: 'Partial refund processed',
+          token: nil,
+          maxApprovalAmount: nil,
+          lender: nil }.stringify_keys!
+      end
+      let(:http_response) { instance_double(HTTParty::Response, parsed_response: success_response, success?: true) }
+
+      before do
+        allow(HTTParty).to receive(:post).with(url, headers: headers, body: refund_body).and_return(http_response)
+      end
+
+      it 'checks response' do
+        response = described_class.call(refund: refund,
+          payment_method: payment_method)
+
+        expect(response).to include('status' => 'ok', 'message' => 'Partial refund processed')
+      end
+    end
+
+    context 'when refund fails' do
+      let(:failed_response) do
+        { timestamp: '2022-09-12T09:18:00.219+00:00',
+          status: 500,
+          error: 'Internal Server Error',
+          message: "",
+          path: '/ecommerce/application/order_token/partial/refund' }.stringify_keys!
+      end
+      let(:http_response) { instance_double(HTTParty::Response, parsed_response: failed_response, success?: false) }
+
+      before do
+        allow(HTTParty).to receive(:post).with(url, headers: headers, body: refund_body).and_return(http_response)
+      end
+
+      it 'raises StandardError' do
+        expect do
+          described_class.call(refund: refund,
+            payment_method: payment_method)
+        end.to raise_error(StandardError, 'Internal Server Error: ')
+      end
+    end
+
+    def refund_body
+      line_item = order.line_items.first
+      { loanAmount: refund.amount,
+        items: [{
+          description: line_item.description,
+          quantity: line_item.quantity,
+          price: line_item.price.to_f
+        }] }.to_json
+    end
+  end
+end


### PR DESCRIPTION
**Issue:** https://linear.app/nebulab-retainers/issue/ABU-23/use-partial-refund-api-for-partial-refunds-in-gatewaycredit

**Brief:** We currently use the [refund API](https://docs.paytomorrow.com/docs/api-reference/api/refund-application) for full refunds and don't allow partial refunds.
There is a [partial refund API](https://docs.paytomorrow.com/docs/api-reference/api/partial-refund-application) that PayTomorrow gives which we can use.

And we don't need to hide partial refund input now.

- [x] QAed both partial and full refund on sandbox and Abunda
