### PR TITLE
Final fixes in extension code

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_pay_tomorrow.js
+++ b/app/assets/javascripts/spree/frontend/solidus_pay_tomorrow.js
@@ -1,5 +1,5 @@
-let orderNumber;
-let paymentMethodId;
+let ptOrderNumber;
+let ptPaymentMethodId;
 let orderToken;
 
 document.addEventListener('DOMContentLoaded', async function () {
@@ -7,8 +7,8 @@ document.addEventListener('DOMContentLoaded', async function () {
         'pay-tomorrow-order-payload'
     );
     if (createOrderPayload){
-        orderNumber = createOrderPayload.dataset.orderNumber;
-        paymentMethodId = createOrderPayload.dataset.paymentMethodId
+        ptOrderNumber = createOrderPayload.dataset.ptOrderNumber;
+        ptPaymentMethodId = createOrderPayload.dataset.ptPaymentMethodId
         orderToken = createOrderPayload.dataset.orderToken;
     }
 })
@@ -19,7 +19,7 @@ async function createOrder() {
     if (createOrderResponse.ok) {
         document.getElementById("card-container").remove()
         document.getElementById("pay-tomorrow-card-button").remove()
-        createOrderStatusDiv.innerHTML = "URL generated. Redirecting to payTomorrow to complete the payment..."
+        createOrderStatusDiv.innerHTML = "<strong>URL generated. Redirecting to payTomorrow to complete the payment...<strong>"
     } else {
         createOrderStatusDiv.innerHTML = "Payment Failed"
     }
@@ -28,9 +28,9 @@ async function createOrder() {
 
 async function createPayTomorrowOrder() {
     const body = JSON.stringify({
-        payment_method: paymentMethodId
+        payment_method: ptPaymentMethodId
     });
-    const resp = await fetch('/api/orders/' + orderNumber + '/pay_tomorrow', {
+    const resp = await fetch('/api/orders/' + ptOrderNumber + '/pay_tomorrow', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/app/views/spree/admin/payments/source_forms/_pay_tomorrow.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_pay_tomorrow.html.erb
@@ -1,0 +1,1 @@
+<p><strong>PayTomorrow payments are only allowed on Frontend for now. You can choose another payment method.</strong></p>

--- a/app/views/spree/checkout/payment/_pay_tomorrow.html.erb
+++ b/app/views/spree/checkout/payment/_pay_tomorrow.html.erb
@@ -5,8 +5,8 @@
 
 <div
   id="pay-tomorrow-order-payload"
-  data-order-number="<%= @order.number %>"
-  data-payment-method-id="<%= payment_method.id %>"
+  data-pt-order-number="<%= @order.number %>"
+  data-pt-payment-method-id="<%= payment_method.id %>"
   data-order-token="<%= @order.guest_token %>"
   >
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-if ENV['PAY_TOMORROW_USERNAME'] && ENV['PAY_TOMORROW_PASSWORD'] && ENV['PAY_TOMORROW_SIGNATURE']
+if ENV['PAY_TOMORROW_USERNAME'] && ENV['PAY_TOMORROW_PASSWORD'] && ENV['PAY_TOMORROW_SIGNATURE'] &&
+  SolidusPayTomorrow::PaymentMethod.count == 0
   SolidusPayTomorrow::PaymentMethod.create!(
     type: 'SolidusPayTomorrow::PaymentMethod',
     name: 'PayTomorrow',

--- a/lib/generators/solidus_pay_tomorrow/install/install_generator.rb
+++ b/lib/generators/solidus_pay_tomorrow/install/install_generator.rb
@@ -17,7 +17,6 @@ module SolidusPayTomorrow
       def add_javascripts
         append_file 'vendor/assets/javascripts/spree/frontend/all.js',
           "//= require spree/frontend/solidus_pay_tomorrow\n"
-        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/solidus_pay_tomorrow\n"
       end
 
       def add_stylesheets


### PR DESCRIPTION
**Issue:** https://linear.app/nebulab-retainers/issue/ABU-26/fixes-in-extension

**Brief:** 
1. The variables in JS file should be prefixed using pt since they are easy to clash with app variables
2. BE specific issues: 
    a. The JS file is not loading when extension is installed. This is because we are adding `spree/backend/solidus_pay_tomorrow` in install_generator but it doesn't exist in extension. Hence removed it

    b. `app/views/spree/admin/payments/source_forms/_pay_tomorrow.html.erb` file should exist. Otherwise code breaks if we try to create a PT payment from BE.

3. Make the SolidusPayTomorrow::PaymentMethod creation idempotent in seed file. Everytime we run the generator, a new payment method is created.


- [x] QAed paytomorrow payments from frontend in sandbox and in Abunda 