### PR TITLE
Open paytomorrow checkout page on the same tab

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_pay_tomorrow.js
+++ b/app/assets/javascripts/spree/frontend/solidus_pay_tomorrow.js
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         cardButton.disabled = true;
         const response = await createOrder();
         if (response.hasOwnProperty('url')) {
-            window.open(response.url, '_blank')
+            window.open(response.url, '_self')
         } else {
             cardButton.disabled = false;
         }


### PR DESCRIPTION
**Brief:** Earlier we used to open a new tab to do the same.
Both seem to have its pros and cons so users of the extension should decide what behavior they want.
By default, we are keeping the flow to continue on the same tab