### PR TITLE
Fix the refund amount in partial refund

### DIFF
--- a/app/services/solidus_pay_tomorrow/client/partial_credit_service.rb
+++ b/app/services/solidus_pay_tomorrow/client/partial_credit_service.rb
@@ -30,8 +30,15 @@ module SolidusPayTomorrow
         "#{api_base_url}/#{PARTIAL_REFUND_ENDPOINT.gsub(':order_token', order_token)}"
       end
 
+      # Note: The way partial refunds work in PT is -
+      # When a partial refund is created, PT actually refunds the whole
+      # loan amount that is authorized during capture,
+      # and a new loan is created for partial refund loanAmount
+      # Hence, the refund that we create is of
+      # payment's loan amount - refund amount to actually only refund
+      # refund.amount
       def partial_refund_body
-        { loanAmount: refund.amount,
+        { loanAmount: refund.payment.amount - refund.amount,
           items: items }
       end
 

--- a/spec/services/solidus_pay_tomorrow/client/partial_credit_service_spec.rb
+++ b/spec/services/solidus_pay_tomorrow/client/partial_credit_service_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe SolidusPayTomorrow::Client::PartialCreditService do
 
     def refund_body
       line_item = order.line_items.first
-      { loanAmount: refund.amount,
+      { loanAmount: payment.amount - refund.amount,
         items: [{
           description: line_item.description,
           quantity: line_item.quantity,


### PR DESCRIPTION
**Ticket:** https://linear.app/nebulab-retainers/issue/ABU-28/change-the-formula-for-creating-partial-refund

**Brief:**
When a partial refund is created, PT actually refunds the whole loan amount that is authorized during capture,
and a new loan is created for partial refund loanAmount
Hence, the refund that we create is of
(payment's loan amount - refund amount) to actually only refund refund.amount

Ref. - https://abunda.slack.com/archives/C02TGH2VC9J/p1671058903468939