### PR TITLE
Gracefully handle PayTomorrow order completion

### DIFF
--- a/app/webhooks/solidus_pay_tomorrow/handlers/notify_handler.rb
+++ b/app/webhooks/solidus_pay_tomorrow/handlers/notify_handler.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  module Handlers
+    class NotifyHandler
+      attr_reader :params
+
+      def initialize(params)
+        @params = params
+      end
+
+      def self.call(params)
+        new(params).call
+      end
+
+      def call
+        case params[:payment_status]
+        when 'pending'
+          SolidusPayTomorrow::Handlers::SuccessHandler.call(order, payment)
+          # There is no need to handle other callbacks right now, if needed,
+          # add here
+        end
+      end
+
+      private
+
+      def payment
+        @payment ||= Spree::Payment.find_by(response_code: params[:uuid])
+      end
+
+      def order
+        @order || payment.order
+      end
+    end
+  end
+end

--- a/app/webhooks/solidus_pay_tomorrow/handlers/success_handler.rb
+++ b/app/webhooks/solidus_pay_tomorrow/handlers/success_handler.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  module Handlers
+    class SuccessHandler
+      attr_reader :order, :payment
+
+      def initialize(order, payment)
+        @order = order
+        @payment = payment
+      end
+
+      def self.call(order, payment)
+        new(order, payment).call
+      end
+
+      def call
+        handle_success unless success_already_handled?
+      end
+
+      private
+
+      def handle_success
+        ActiveRecord::Base.transaction do
+          update_payment
+          update_order
+        end
+      end
+
+      # If auto_capture is disabled, the payment is already processed and
+      # it'll be captured from admin. Marking as pending is necessary to avoid
+      # calling authorize! in this case
+      def update_payment
+        payment.update!(state: :pending) if should_update_payment?
+      end
+
+      def should_update_payment?
+        !payment.payment_method.auto_capture?
+      end
+
+      def update_order
+        order.next!
+      end
+
+      def success_already_handled?
+        order.completed? || order.confirm?
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,6 @@ Spree::Core::Engine.routes.draw do
     as: 'pay_tomorrow_return'
   get 'pay_tomorrow/cancel', to: '/solidus_pay_tomorrow/order_application#cancel',
     as: 'pay_tomorrow_cancel'
+  post 'pay_tomorrow/notify', to: '/solidus_pay_tomorrow/api/webhooks#notify',
+    as: 'pay_tomorrow_notify'
 end

--- a/lib/generators/solidus_pay_tomorrow/install/install_generator.rb
+++ b/lib/generators/solidus_pay_tomorrow/install/install_generator.rb
@@ -47,6 +47,10 @@ module SolidusPayTomorrow
           'solidus_pay_tomorrow_order_application_controller.rb',
           'app/controllers/solidus_pay_tomorrow/order_application_controller.rb'
         )
+        template(
+          'solidus_pay_tomorrow_api_webhooks_controller.rb',
+          'app/controllers/solidus_pay_tomorrow/api/webhooks_controller.rb'
+        )
       end
     end
   end

--- a/lib/generators/solidus_pay_tomorrow/install/templates/solidus_pay_tomorrow_api_webhooks_controller.rb
+++ b/lib/generators/solidus_pay_tomorrow/install/templates/solidus_pay_tomorrow_api_webhooks_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module SolidusPayTomorrow
+  module Api
+    class WebhooksController < BaseController
+      skip_before_action :authenticate_user
+      skip_before_action :verify_authenticity_token
+      before_action :verify_pay_tomorrow_request
+
+      def notify
+        SolidusPayTomorrow::Handlers::NotifyHandler.call(params)
+        return_ok("Handled!")
+      end
+
+      private
+
+      # We don't get any unique key to identify PayTomorrow webhooks, so we check if order is in our system
+      # and proceed if it is, otherwise return
+      def verify_pay_tomorrow_request
+        return if payment.present?
+
+        return_ok("Couldn't find payment with uuid: #{params[:uuid]}")
+      end
+
+      def payment
+        @payment = Spree::Payment.find_by(response_code: params[:uuid])
+      end
+
+      # We return 200 in all cases because PayTomorrow retries requests
+      def return_ok(message)
+        render json: { message: message }, status: :ok
+      end
+    end
+  end
+end

--- a/lib/generators/solidus_pay_tomorrow/install/templates/solidus_pay_tomorrow_order_application_controller.rb
+++ b/lib/generators/solidus_pay_tomorrow/install/templates/solidus_pay_tomorrow_order_application_controller.rb
@@ -3,20 +3,16 @@
 module SolidusPayTomorrow
   class OrderApplicationController < Spree::StoreController
     def success
-      # If auto_capture is disabled, the payment is already processed and
-      # it'll be captured from admin. Marking as pending is necessary to avoid
-      # calling authorize! in this case
-      payment.update!(state: :pending) unless payment.payment_method.auto_capture?
-      current_order.next!
+      SolidusPayTomorrow::Handlers::SuccessHandler.call(current_order, payment)
 
-      flash[:notice] = 'Payment Successful!'
+      flash[:notice] = 'PayTomorrow Application Successful!'
       redirect_to checkout_state_path('confirm')
     end
 
     def cancel
       payment.update!(state: :invalid)
 
-      flash[:error] = "Payment failed!"
+      flash[:error] = "PayTomorrow Application failed!"
       redirect_to checkout_state_path('payment')
     end
 

--- a/spec/requests/solidus_pay_tomorrow/api/webhooks_controller_spec.rb
+++ b/spec/requests/solidus_pay_tomorrow/api/webhooks_controller_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::Api::WebhooksController, type: :request do
+  subject(:notify_pending_call) do
+    post "/pay_tomorrow/notify", params: pending_params
+  end
+
+  let(:payment_method) { create(:pt_payment_method) }
+  let(:payment_source) { create(:pt_payment_source, payment_method: payment_method) }
+
+  describe 'POST /pay_tomorrow/notify' do
+    context 'when uuid verification fails' do
+      let(:pending_params) {
+        { txn_type: 'cart',
+          payment_status: 'pending',
+          pt_currency: 'USD',
+          pt_amount: 100,
+          uuid: 'an invalid uuid' }
+      }
+
+      it 'gracefully returns with error message' do
+        notify_pending_call
+        expect(response.status).to be(200)
+        expect(JSON(response.body)['message']).to \
+          eq("Couldn't find payment with uuid: an invalid uuid")
+      end
+    end
+
+    context 'when user does not click on Close button on PayTomorrow page' do
+      # In this case, the application is completed, but since user hasn't been
+      # redirected to pay_tomorrow_return endpoint, the order isn't updated
+      # This should be done by the Notify webhook
+      let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:delivery) }
+      let(:payment) {
+        create(:payment, order: order, payment_method: payment_method, source: payment_source,
+          state: :checkout, response_code: payment_source.application_token,
+          amount: order.total)
+      }
+      let(:pending_params) {
+        { txn_type: 'cart',
+          payment_status: 'pending',
+          pt_currency: 'USD',
+          pt_amount: order.amount,
+          uuid: payment.response_code }
+      }
+
+      it 'updates the order accordingly' do
+        # Ensure that the order is in 'payment' state and payment is in 'checkout' state
+        # before the request
+        expect(order.state).to eq('payment')
+        expect(payment.reload.state).to eq('checkout')
+        notify_pending_call
+        expect(order.reload.state).to eq('confirm')
+      end
+    end
+
+    context 'when user clicks on Close button on PayTomorrow page' do
+      # In this case, the application is completed, and user clicked the close
+      # button and got redirected to pay_tomorrow_return endpoint,
+      # the order is already handled.
+      # Notify webhook should do nothing in this case
+      let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
+      let(:payment) {
+        create(:payment, order: order, payment_method: payment_method, source: payment_source,
+          state: :checkout, response_code: payment_source.application_token,
+          amount: order.total)
+      }
+      let(:pending_params) {
+        { txn_type: 'cart',
+          payment_status: 'pending',
+          pt_currency: 'USD',
+          pt_amount: order.amount,
+          uuid: payment.response_code }
+      }
+
+      it 'does nothing, order already updated' do
+        # Ensure that the order is in 'confirm' state and payment is in 'checkout' state
+        # before the request
+        expect(order.state).to eq('confirm')
+        expect(payment.reload.state).to eq('checkout')
+        notify_pending_call
+        expect(order.reload.state).to eq('confirm')
+      end
+    end
+  end
+end

--- a/spec/webhooks/solidus_pay_tomorrow/handlers/notify_handler_spec.rb
+++ b/spec/webhooks/solidus_pay_tomorrow/handlers/notify_handler_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::Handlers::NotifyHandler do
+  subject(:handler) { described_class.new({}) }
+
+  let(:payment_method) { create(:pt_payment_method) }
+  let(:payment_source) { create(:pt_payment_source, payment_method: payment_method) }
+
+  it { expect(described_class).to respond_to(:call).with(1).arguments }
+
+  it { expect(handler).to respond_to(:call).with(0).arguments }
+
+  context 'when notify is for pending callback' do
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:delivery) }
+    let(:payment) {
+      create(:payment, order: order, payment_method: payment_method, source: payment_source,
+        state: :checkout, response_code: payment_source.application_token,
+        amount: order.total)
+    }
+    let(:pending_params) {
+      { txn_type: 'cart',
+        payment_status: 'pending',
+        pt_currency: 'USD',
+        pt_amount: 100,
+        uuid: payment.response_code }
+    }
+
+    it 'calls the SuccessHandler with correct params' do
+      allow(SolidusPayTomorrow::Handlers::SuccessHandler).to receive(:call).with(order, payment)
+      described_class.call(pending_params)
+      expect(SolidusPayTomorrow::Handlers::SuccessHandler).to have_received(:call).with(order, payment)
+    end
+  end
+end

--- a/spec/webhooks/solidus_pay_tomorrow/handlers/success_handler_spec.rb
+++ b/spec/webhooks/solidus_pay_tomorrow/handlers/success_handler_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusPayTomorrow::Handlers::SuccessHandler do
+  subject(:handler) { described_class.new(double, double) }
+
+  let(:payment_method) { create(:pt_payment_method) }
+  let(:payment_source) { create(:pt_payment_source, payment_method: payment_method) }
+
+  it { expect(described_class).to respond_to(:call).with(2).arguments }
+
+  it { expect(handler).to respond_to(:call).with(0).arguments }
+
+  context 'when order is still in payment state' do
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:delivery) }
+    let(:payment) {
+      create(:payment, order: order, payment_method: payment_method, source: payment_source,
+        state: :checkout, response_code: payment_source.application_token,
+        amount: order.total)
+    }
+
+    it 'update the order' do
+      expect(order.state).to eq('payment')
+      described_class.call(order, payment)
+      expect(order.reload.state).to eq('confirm')
+    end
+  end
+
+  context 'when order is already confirmed' do
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
+    let(:payment) {
+      create(:payment, order: order, payment_method: payment_method, source: payment_source,
+        state: :checkout, response_code: payment_source.application_token,
+        amount: order.total)
+    }
+
+    it "doesn't do anything" do
+      expect(order.state).to eq('confirm')
+      described_class.call(order, payment)
+      expect(order.reload.state).to eq('confirm')
+    end
+  end
+end


### PR DESCRIPTION
**Ticket:** https://linear.app/nebulab-retainers/issue/ABU-8/create-webhook-for-paytomorrow-order-notify

**Brief:**
Currently when a PT order is completed, we handle order completion only and iff user clicks on the Close button on the PT page. This is a problem because user can very well close the tab and we'll miss to update the order.
This PR intends to solve this by handling the PT [notify webhook](https://docs.paytomorrow.com/docs/api-reference/postbacks/payment-pending-postback)
 