### PR TITLE
Fix loading bug

### DIFF
--- a/lib/solidus_pay_tomorrow/engine.rb
+++ b/lib/solidus_pay_tomorrow/engine.rb
@@ -13,16 +13,14 @@ module SolidusPayTomorrow
 
     initializer 'solidus_pay_tomorrow.add_static_preference', after: 'spree.register.payment_methods' do |app|
       app.config.spree.payment_methods << 'SolidusPayTomorrow::PaymentMethod'
-      app.config.to_prepare do
-        Spree::Config.static_model_preferences.add(
-          SolidusPayTomorrow::PaymentMethod,
-          'pt_credentials', {
-            username: ENV['PAY_TOMORROW_USERNAME'],
-            password: ENV['PAY_TOMORROW_PASSWORD'],
-            signature: ENV['PAY_TOMORROW_SIGNATURE']
-          }
-        )
-      end
+      Spree::Config.static_model_preferences.add(
+        SolidusPayTomorrow::PaymentMethod,
+        'pt_credentials', {
+          username: ENV['PAY_TOMORROW_USERNAME'],
+          password: ENV['PAY_TOMORROW_PASSWORD'],
+          signature: ENV['PAY_TOMORROW_SIGNATURE']
+        }
+      )
     end
 
     # use rspec for tests


### PR DESCRIPTION
Adding a static model preference doesn't need to be wrapped in a `app.config.to_prepare` block (see https://github.com/solidusio-contrib/solidus_viabill/blob/main/lib/solidus_viabill/engine.rb#L16).

Having it in the block means that every time we modify the app it tries to load the credentials again even though they are already defined, which returns an error.

![299824016-af046ebe-23af-4870-a123-c158069992d0](https://github.com/user-attachments/assets/cfbcdbda-8112-4775-b32f-f5958f33c232)

